### PR TITLE
Fix infinite loop on landing page

### DIFF
--- a/Atomia.Store.AspNetMvc/Controllers/CheckoutController.cs
+++ b/Atomia.Store.AspNetMvc/Controllers/CheckoutController.cs
@@ -77,6 +77,12 @@ namespace Atomia.Store.AspNetMvc.Controllers
 
                 var orderContext = new OrderContext(cart, contactDataCollection, paymentData, new object[] { Request });
                 var result = orderPlacementService.PlaceOrder(orderContext);
+                
+                if (result.RedirectUrl == urlProvider.SuccessUrl)
+                {
+                    contactDataProvider.ClearContactData();
+                    cartProvider.ClearCart();
+                }
 
                 return Redirect(result.RedirectUrl);
             }
@@ -117,6 +123,8 @@ namespace Atomia.Store.AspNetMvc.Controllers
 	        {
                 case PaymentTransaction.Ok:
                 case PaymentTransaction.InProgress:
+                    contactDataProvider.ClearContactData();
+                    cartProvider.ClearCart();
                     redirectUrl = urlProvider.SuccessUrl;
                     break;
 


### PR DESCRIPTION
When 'LandingAfterOrder' is set to 'true' and you order something from
the store you will be redirected to the landing page. Then you logged
out and return to the store, you will see that cart is not empty (has
items from the last order). After you order those items, you will be
redirected to the landing page with infinity loop. This is changed and
now before you are redirected to the landing page, card and contact
data will be removed from the store session.

Resolves PROD-294

Changelog
* [FIX] Fixed infinite loop on landing page

Change-Id: Iff7b05cec46e8682bfb4b4273fca6c01e09b1efa