### PR TITLE
Remove headers from HTTPS response

### DIFF
--- a/Atomia.Store.Themes.Default/Global.asax.cs
+++ b/Atomia.Store.Themes.Default/Global.asax.cs
@@ -145,6 +145,10 @@ namespace Atomia.Store.Themes.Default
         /// <param name="e">The <see cref="System.EventArgs"/> instance containing the event data.</param>
         protected void Application_PreSendRequestHeaders(object sender, EventArgs e)
         {
+            HttpContext.Current.Response.Headers.Remove("X-Powered-By");
+            HttpContext.Current.Response.Headers.Remove("X-AspNet-Version");
+            HttpContext.Current.Response.Headers.Remove("X-AspNetMvc-Version");
+            HttpContext.Current.Response.Headers.Remove("Server");
             this.HandlerClass.Application_PreSendRequestHeaders(sender, e);
         }
 

--- a/Atomia.Store.Themes.Default/Original Files/Web.config
+++ b/Atomia.Store.Themes.Default/Original Files/Web.config
@@ -450,6 +450,14 @@
       <remove name="TRACEVerbHandler"/>
       <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0"/>
     </handlers>
+    <httpProtocol>
+      <customHeaders>
+        <remove name="X-Powered-By" />
+      </customHeaders>
+      <redirectHeaders>
+        <clear />
+      </redirectHeaders>
+    </httpProtocol>
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">


### PR DESCRIPTION
Requested headers from HTTPS response are removed in code, in
AtomiaGUI, Store, Identity and GDPR applications.

Partially resolves PROD-1623. (2/4)

ChangeLog:
*[IMPROVMENT] Removed headers from HTTPS response.

Change-Id: Idd73dd46cfa668b8771a5388376c49c3a4c84b9a