### PR TITLE
Fix translations resetting on store checkout page

### DIFF
--- a/Atomia.Store.AspNetMvc/Controllers/CheckoutController.cs
+++ b/Atomia.Store.AspNetMvc/Controllers/CheckoutController.cs
@@ -86,7 +86,7 @@ namespace Atomia.Store.AspNetMvc.Controllers
 
                 return Redirect(result.RedirectUrl);
             }
-
+            model = DependencyResolver.Current.GetService<CheckoutViewModel>();
             return View(model);
         }
 

--- a/Atomia.Store.AspNetMvc/Controllers/CheckoutController.cs
+++ b/Atomia.Store.AspNetMvc/Controllers/CheckoutController.cs
@@ -86,7 +86,7 @@ namespace Atomia.Store.AspNetMvc.Controllers
 
                 return Redirect(result.RedirectUrl);
             }
-            model = DependencyResolver.Current.GetService<CheckoutViewModel>();
+
             return View(model);
         }
 

--- a/Atomia.Store.AspNetMvc/Filters/LanguageFilter.cs
+++ b/Atomia.Store.AspNetMvc/Filters/LanguageFilter.cs
@@ -14,7 +14,7 @@ namespace Atomia.Store.AspNetMvc.Filters
         {
             var request = filterContext.HttpContext.Request;
             
-            if (filterContext.Controller.ControllerContext.IsChildAction && request.IsAjaxRequest())
+            if (filterContext.Controller.ControllerContext.IsChildAction)
             {
                 return;
             }

--- a/Atomia.Store.AspNetMvc/Filters/LanguageFilter.cs
+++ b/Atomia.Store.AspNetMvc/Filters/LanguageFilter.cs
@@ -14,7 +14,7 @@ namespace Atomia.Store.AspNetMvc.Filters
         {
             var request = filterContext.HttpContext.Request;
             
-            if (filterContext.Controller.ControllerContext.IsChildAction || request.IsAjaxRequest())
+            if (filterContext.Controller.ControllerContext.IsChildAction && request.IsAjaxRequest())
             {
                 return;
             }

--- a/Atomia.Store.AspNetMvc/Infrastructure/ModelBinding.cs
+++ b/Atomia.Store.AspNetMvc/Infrastructure/ModelBinding.cs
@@ -1,5 +1,7 @@
 ﻿using Atomia.Store.AspNetMvc.Ports;
+using Atomia.Store.Core;
 using System;
+using System.Threading;
 using System.Web.Mvc;
 
 namespace Atomia.Store.AspNetMvc.Infrastructure
@@ -14,6 +16,13 @@ namespace Atomia.Store.AspNetMvc.Infrastructure
         /// </summary>
         public override object BindModel(ControllerContext controllerContext, ModelBindingContext bindingContext)
         {
+            var culture = DependencyResolver.Current.GetService<ILanguagePreferenceProvider>().GetCurrentLanguage().AsCultureInfo();
+            if (System.Globalization.CultureInfo.CurrentCulture != culture)
+            {
+                Thread.CurrentThread.CurrentCulture = culture;
+                Thread.CurrentThread.CurrentUICulture = culture;
+            }
+
             var model = DependencyResolver.Current.GetService(bindingContext.ModelType);
 
             if (model != null)

--- a/Atomia.Store.PublicBillingApi/Adapters/TermsOfServiceProvider.cs
+++ b/Atomia.Store.PublicBillingApi/Adapters/TermsOfServiceProvider.cs
@@ -85,13 +85,8 @@ namespace Atomia.Store.PublicBillingApi.Adapters
 
             foreach (var resource in tosResources)
             {
-                termsOfService.Add(new TermsOfService
-                {
-                    Id = resource,
-                    Name = resourceProvider.GetResource(resource + "_Name"),
-                    Terms = resourceProvider.GetResource(resource + "_Terms"),
-                    Link = resourceProvider.GetResource(resource + "_Link")
-                });
+                TermsOfService tosResource = this.GetTermsOfService(resource);
+                termsOfService.Add(tosResource);
             }
 
             return termsOfService;

--- a/Atomia.Store.Themes.Default/Themes/Default/Views/Checkout/_TermsOfServiceConfirmation.cshtml
+++ b/Atomia.Store.Themes.Default/Themes/Default/Views/Checkout/_TermsOfServiceConfirmation.cshtml
@@ -16,6 +16,7 @@
                     @Html.LabelFor(m => m.TermsOfService[i].Confirm, Html.CommonResource("ReadAndAgree")) @Html.ActionLink(Model.TermsOfService[i].Name, "TermsOfService", new { Id = Model.TermsOfService[i].Id }, new { target = "_blank" })
                     @Html.ValidationMessageFor(m => m.TermsOfService[i].Confirm)
                     @Html.HiddenFor(m => m.TermsOfService[i].Id)
+                    @Html.HiddenFor(m => m.TermsOfService[i].Name)
                 </div>
             }
         </div>


### PR DESCRIPTION
Fixed an issue that caused the terms and conditions on the store
checkout page to reset to default language after sending non valid form
data.

Resolves PROD-1615.

ChangeLog:
* [FIX] Fixed translations resetting on store checkout page when Terms
and Conditions are not accepted.