### PR TITLE
Add option to fetch error messages from resources

### DIFF
--- a/Atomia.Store.AspNetMvc/Controllers/CheckoutController.cs
+++ b/Atomia.Store.AspNetMvc/Controllers/CheckoutController.cs
@@ -36,6 +36,7 @@ namespace Atomia.Store.AspNetMvc.Controllers
             ViewBag.CheckVAT = !String.IsNullOrEmpty(vatDataProvider.VatNumber);
             
             var model = DependencyResolver.Current.GetService<CheckoutViewModel>();
+            ViewData["formHasErrors"] = false;
 
             return View(model);
         }
@@ -87,6 +88,7 @@ namespace Atomia.Store.AspNetMvc.Controllers
                 return Redirect(result.RedirectUrl);
             }
 
+            ViewData["formHasErrors"] = true;
             return View(model);
         }
 

--- a/Atomia.Store.AspNetMvc/Filters/LanguageFilter.cs
+++ b/Atomia.Store.AspNetMvc/Filters/LanguageFilter.cs
@@ -34,8 +34,8 @@ namespace Atomia.Store.AspNetMvc.Filters
             var currentLanguage = languagePreferenceProvider.GetCurrentLanguage();
             var currentCulture = currentLanguage.AsCultureInfo();
 
-            Thread.CurrentThread.CurrentCulture = currentCulture;
-            Thread.CurrentThread.CurrentUICulture = currentCulture;
+            System.Globalization.CultureInfo.DefaultThreadCurrentCulture = currentCulture;
+            System.Globalization.CultureInfo.DefaultThreadCurrentUICulture = currentCulture;
         }
     }
 }

--- a/Atomia.Store.AspNetMvc/Filters/LanguageFilter.cs
+++ b/Atomia.Store.AspNetMvc/Filters/LanguageFilter.cs
@@ -14,7 +14,7 @@ namespace Atomia.Store.AspNetMvc.Filters
         {
             var request = filterContext.HttpContext.Request;
             
-            if (filterContext.Controller.ControllerContext.IsChildAction || request.IsAjaxRequest())
+            if (filterContext.Controller.ControllerContext.IsChildAction)
             {
                 return;
             }

--- a/Atomia.Store.AspNetMvc/Infrastructure/ModelBinding.cs
+++ b/Atomia.Store.AspNetMvc/Infrastructure/ModelBinding.cs
@@ -1,5 +1,7 @@
 ﻿using Atomia.Store.AspNetMvc.Ports;
+using Atomia.Store.Core;
 using System;
+using System.Threading;
 using System.Web.Mvc;
 
 namespace Atomia.Store.AspNetMvc.Infrastructure
@@ -14,6 +16,13 @@ namespace Atomia.Store.AspNetMvc.Infrastructure
         /// </summary>
         public override object BindModel(ControllerContext controllerContext, ModelBindingContext bindingContext)
         {
+            var culture = DependencyResolver.Current.GetService<ILanguagePreferenceProvider>().GetCurrentLanguage().AsCultureInfo();
+            if (System.Globalization.CultureInfo.CurrentCulture != culture)
+            {
+                Thread.CurrentThread.CurrentCulture = culture;
+                Thread.CurrentThread.CurrentUICulture = culture;
+            }
+
             var model = DependencyResolver.Current.GetService(bindingContext.ModelType);
 
             if (model != null)

--- a/Atomia.Store.AspNetMvc/Infrastructure/ModelBinding.cs
+++ b/Atomia.Store.AspNetMvc/Infrastructure/ModelBinding.cs
@@ -16,13 +16,6 @@ namespace Atomia.Store.AspNetMvc.Infrastructure
         /// </summary>
         public override object BindModel(ControllerContext controllerContext, ModelBindingContext bindingContext)
         {
-            var culture = DependencyResolver.Current.GetService<ILanguagePreferenceProvider>().GetCurrentLanguage().AsCultureInfo();
-            if (System.Globalization.CultureInfo.CurrentCulture != culture)
-            {
-                Thread.CurrentThread.CurrentCulture = culture;
-                Thread.CurrentThread.CurrentUICulture = culture;
-            }
-
             var model = DependencyResolver.Current.GetService(bindingContext.ModelType);
 
             if (model != null)

--- a/Atomia.Store.PublicBillingApi/Adapters/TermsOfServiceProvider.cs
+++ b/Atomia.Store.PublicBillingApi/Adapters/TermsOfServiceProvider.cs
@@ -85,13 +85,8 @@ namespace Atomia.Store.PublicBillingApi.Adapters
 
             foreach (var resource in tosResources)
             {
-                termsOfService.Add(new TermsOfService
-                {
-                    Id = resource,
-                    Name = resourceProvider.GetResource(resource + "_Name"),
-                    Terms = resourceProvider.GetResource(resource + "_Terms"),
-                    Link = resourceProvider.GetResource(resource + "_Link")
-                });
+                TermsOfService tosResource = this.GetTermsOfService(resource);
+                termsOfService.Add(tosResource);
             }
 
             return termsOfService;

--- a/Atomia.Store.Themes.Default/App_GlobalResources/Common.designer.cs
+++ b/Atomia.Store.Themes.Default/App_GlobalResources/Common.designer.cs
@@ -684,6 +684,15 @@ namespace Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You must confirm the Terms of Service..
+        /// </summary>
+        internal static string ErrorConfirm {
+            get {
+                return ResourceManager.GetString("ErrorConfirm", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Not a valid credit card number.
         /// </summary>
         internal static string ErrorCreditCard {

--- a/Atomia.Store.Themes.Default/App_GlobalResources/Common.resx
+++ b/Atomia.Store.Themes.Default/App_GlobalResources/Common.resx
@@ -761,4 +761,7 @@
   <data name="CustomerLogin" xml:space="preserve">
     <value>Login</value>
   </data>
+  <data name="ErrorConfirm" xml:space="preserve">
+    <value>You must confirm the Terms of Service.</value>
+  </data>
 </root>

--- a/Atomia.Store.Themes.Default/App_GlobalResources/Common.sv-SE.resx
+++ b/Atomia.Store.Themes.Default/App_GlobalResources/Common.sv-SE.resx
@@ -752,4 +752,7 @@
   <data name="CustomerLogin" xml:space="preserve">
     <value>Logga in</value>
   </data>
+  <data name="ErrorConfirm" xml:space="preserve">
+    <value>Du måste läsa och godkänna alla avtal.</value>
+  </data>
 </root>

--- a/Atomia.Store.Themes.Default/Themes/Default/Views/Checkout/_TermsOfServiceConfirmation.cshtml
+++ b/Atomia.Store.Themes.Default/Themes/Default/Views/Checkout/_TermsOfServiceConfirmation.cshtml
@@ -1,6 +1,9 @@
 ﻿@model Atomia.Store.AspNetMvc.Models.DefaultCheckoutViewModel
 
 <!-- ko if: termsOfService().length > 0 -->
+@{
+    var formHasErrors = Boolean.Parse(ViewData["formHasErrors"].ToString());
+}
 @if (Model.TermsOfService.Count > 0)
 {
     <h4>@Html.CommonResource("Terms")</h4>
@@ -14,7 +17,7 @@
                     @Html.LabelFor(m => m.TermsOfService[i].Confirm, " ")
                     @Html.LabelFor(m => m.TermsOfService[i].Confirm, " ")
                     @Html.LabelFor(m => m.TermsOfService[i].Confirm, Html.CommonResource("ReadAndAgree")) @Html.ActionLink(Model.TermsOfService[i].Name, "TermsOfService", new { Id = Model.TermsOfService[i].Id }, new { target = "_blank" })
-                    @Html.ValidationMessageFor(m => m.TermsOfService[i].Confirm)
+                    @Html.ValidationMessageFor(m => m.TermsOfService[i].Confirm, formHasErrors ? Html.CommonResource("ErrorTermNotChecked") : "")
                     @Html.HiddenFor(m => m.TermsOfService[i].Id)
                 </div>
             }

--- a/Atomia.Store.Themes.Default/Themes/Default/Views/Checkout/_TermsOfServiceConfirmation.cshtml
+++ b/Atomia.Store.Themes.Default/Themes/Default/Views/Checkout/_TermsOfServiceConfirmation.cshtml
@@ -19,6 +19,7 @@
                     @Html.LabelFor(m => m.TermsOfService[i].Confirm, Html.CommonResource("ReadAndAgree")) @Html.ActionLink(Model.TermsOfService[i].Name, "TermsOfService", new { Id = Model.TermsOfService[i].Id }, new { target = "_blank" })
                     @Html.ValidationMessageFor(m => m.TermsOfService[i].Confirm, formHasErrors ? Html.CommonResource("ErrorTermNotChecked") : "")
                     @Html.HiddenFor(m => m.TermsOfService[i].Id)
+                    @Html.HiddenFor(m => m.TermsOfService[i].Name)
                 </div>
             }
         </div>

--- a/Atomia.Store.Themes.Default/Themes/Default/Views/Shared/_ValidationSummary.cshtml
+++ b/Atomia.Store.Themes.Default/Themes/Default/Views/Shared/_ValidationSummary.cshtml
@@ -4,6 +4,7 @@
 
 @{
     var formHasErrors = Model.Any(x => x.Value.Errors.Count > 0);
+    int i = 0;
 }
 
 @if (formHasErrors)
@@ -12,7 +13,9 @@
         <ul>
             @foreach (var kv in Model.Where(x => x.Value.Errors.Count > 0))
             {
-                <li><strong>@Html.CommonResource(kv.Key.Split('.').Last()):</strong> @String.Join(", ", kv.Value.Errors.Select(e => e.ErrorMessage))</li>
+                string errorMessage = string.IsNullOrEmpty(Html.Resource("CustomerValidation, " + kv.Key.Split('.').Last())) ? Html.CommonResource("Error" + kv.Key.Split('.').Last()) : Html.Resource("CustomerValidation, " + kv.Key.Split('.').Last());
+                <li><strong>@Html.CommonResource(kv.Key.Split('.').Last()):</strong> @String.Join(", ", string.IsNullOrEmpty(errorMessage) ? kv.Value.Errors.Select(e => e.ErrorMessage).ElementAt(i) : errorMessage)</li>
+                i++;
             }
         </ul>
     </div>


### PR DESCRIPTION
Added option to fetch error messages from resources. In case the
resource doesn't contain an error message, the error message is fetched
from the ModelState dictionary. Also fixed issue with current culture
resetting in the model binding thread.

Resolves PROD-1615.

ChangeLog:
* [FIX] Fixed error message localizations in Store.