### PR TITLE
PackageGroupId to all order line items

### DIFF
--- a/Atomia.Store.PublicBillingApi/Handlers/OrderDataHandler.cs
+++ b/Atomia.Store.PublicBillingApi/Handlers/OrderDataHandler.cs
@@ -86,7 +86,6 @@ namespace Atomia.Store.PublicBillingApi.Handlers
         {
             PublicOrderItem existingOrderItem = null;
             var domainAttr = item.CartItem.CustomAttributes.FirstOrDefault(ca => ca.Name == "DomainName");
-
             if (domainAttr != null)
             {
                 existingOrderItem = order.OrderItems.FirstOrDefault(orderItem =>

--- a/Atomia.Store.PublicOrderHandlers/Atomia.Store.PublicOrderHandlers.csproj
+++ b/Atomia.Store.PublicOrderHandlers/Atomia.Store.PublicOrderHandlers.csproj
@@ -67,6 +67,7 @@
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Abstractions" />
     <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Web.Services" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -88,6 +89,7 @@
     <Compile Include="CurrencyHandler.cs" />
     <Compile Include="DomainRegContactProvider.cs" />
     <Compile Include="OrderAttributesHandler.cs" />
+    <Compile Include="PackageGroupIdHandler.cs" />
     <Compile Include="TransactionDataHandlers\PaymentProfileHandler.cs" />
     <Compile Include="TransactionDataHandlers\RequestParamsHandler.cs" />
     <Compile Include="IpAddressHandler.cs" />

--- a/Atomia.Store.PublicOrderHandlers/PackageGroupIdHandler.cs
+++ b/Atomia.Store.PublicOrderHandlers/PackageGroupIdHandler.cs
@@ -1,0 +1,59 @@
+﻿using Atomia.Store.PublicBillingApi.Handlers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Atomia.Web.Plugin.OrderServiceReferences.AtomiaBillingPublicService;
+
+namespace Atomia.Store.PublicOrderHandlers
+{
+    /// <summary>
+    /// Handler to amend order with the package group id when the multipackage is enabled.
+    /// </summary>
+    public class PackageGroupIdHandler : OrderDataHandler
+    {
+        private readonly AtomiaBillingPublicService _atomiaBillingPublicService;
+
+        /// <summary>
+        /// Create a new instance of the handler.
+        /// </summary>
+        /// <param name="atomiaBillingPublicService">The atomia billing public service instance.</param>
+        public PackageGroupIdHandler(AtomiaBillingPublicService atomiaBillingPublicService)
+        {
+            _atomiaBillingPublicService = atomiaBillingPublicService;
+        }
+
+        /// <summary>
+        /// Amends the order with the package group id whene the multipackage is enabled
+        /// </summary>
+        public override PublicOrder AmendOrder(PublicOrder order, PublicOrderContext orderContext)
+        {
+            if (_atomiaBillingPublicService.IsMultiPackageEnabled())
+            {
+                var packageGroupId = Guid.NewGuid().ToString();
+                foreach (var item in order.OrderItems)
+                {
+                    var packageGroupIdArray = new PublicOrderItemProperty[1]
+                    {
+                        new PublicOrderItemProperty
+                        {
+                            Name = "PackageGroupId",
+                            Value = packageGroupId
+                        }
+                    };
+
+                    if (item.CustomData == null)
+                    {
+                        item.CustomData = packageGroupIdArray;
+                        continue;
+                    }
+
+                    item.CustomData = item.CustomData.Concat(packageGroupIdArray).ToArray();
+                }
+            }
+
+            return order;
+        }
+    }
+}

--- a/Atomia.Store.PublicOrderHandlers/PackageGroupIdHandler.cs
+++ b/Atomia.Store.PublicOrderHandlers/PackageGroupIdHandler.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Atomia.Web.Plugin.OrderServiceReferences.AtomiaBillingPublicService;
+using Atomia.Store.Core;
 
 namespace Atomia.Store.PublicOrderHandlers
 {
@@ -13,15 +14,23 @@ namespace Atomia.Store.PublicOrderHandlers
     /// </summary>
     public class PackageGroupIdHandler : OrderDataHandler
     {
-        private readonly AtomiaBillingPublicService _atomiaBillingPublicService;
+        /// <summary>
+        /// The package provider instance
+        /// </summary>
+        private readonly IPackageProvider _packageProvider;
 
         /// <summary>
         /// Create a new instance of the handler.
         /// </summary>
-        /// <param name="atomiaBillingPublicService">The atomia billing public service instance.</param>
-        public PackageGroupIdHandler(AtomiaBillingPublicService atomiaBillingPublicService)
+        /// <param name="packageProvider">The package provider instance.</param>
+        public PackageGroupIdHandler(IPackageProvider packageProvider)
         {
-            _atomiaBillingPublicService = atomiaBillingPublicService;
+            if (packageProvider == null)
+            {
+                throw new ArgumentNullException(nameof(IPackageProvider));
+            }
+
+            _packageProvider = packageProvider;
         }
 
         /// <summary>
@@ -29,7 +38,7 @@ namespace Atomia.Store.PublicOrderHandlers
         /// </summary>
         public override PublicOrder AmendOrder(PublicOrder order, PublicOrderContext orderContext)
         {
-            if (_atomiaBillingPublicService.IsMultiPackageEnabled())
+            if (_packageProvider.IsMultiPackageEnabled())
             {
                 var packageGroupId = Guid.NewGuid().ToString();
                 foreach (var item in order.OrderItems)

--- a/Atomia.Store.Themes.Default/App_Start/UnityConfig.cs
+++ b/Atomia.Store.Themes.Default/App_Start/UnityConfig.cs
@@ -213,8 +213,7 @@ namespace Atomia.Store.Themes.Default
         private static ResolvedArrayParameter<OrderDataHandler> GetOrderDataHandlerParams()
         {
             // We resolve the parameters manually to control the order the OrderHandlers are applied.
-            var orderDataHandlerParams = new List<ResolvedParameter<OrderDataHandler>>
-            {
+            return new ResolvedArrayParameter<OrderDataHandler>(
                 new ResolvedParameter<OrderDataHandler>("Reseller"),
                 new ResolvedParameter<OrderDataHandler>("LanguageHandler"),
                 new ResolvedParameter<OrderDataHandler>("Currency"),
@@ -229,6 +228,8 @@ namespace Atomia.Store.Themes.Default
                 new ResolvedParameter<OrderDataHandler>("OwnDomain"),
                 new ResolvedParameter<OrderDataHandler>("SetupFees"),
 
+                // PackageGroupId handler will add package group id to all order lines, if the multipackage is enabled.
+                new ResolvedParameter<OrderDataHandler>("PackageGroupId"),
                 // This is a good position for TLD specific handlers.
 
                 // Default should be placed after all other handlers that add items form the cart to the order, or there is risk of adding the same item twice.
@@ -237,11 +238,8 @@ namespace Atomia.Store.Themes.Default
                 // This is a good position for handlers that add extra items depending on other items in cart, e.g. like HST-APPY in old order page.
 
                 // RemovePostOrder should be placed last to make sure any added postal fees are removed, since they will be added by Atomia Billing.
-                new ResolvedParameter<OrderDataHandler>("RemovePostOrder"),
-                new ResolvedParameter<OrderDataHandler>("PackageGroupId")
-            };
-
-            return new ResolvedArrayParameter<OrderDataHandler>(orderDataHandlerParams.ToArray());
+                new ResolvedParameter<OrderDataHandler>("RemovePostOrder")
+            );
         }
 
         /// <summary>

--- a/Atomia.Store.Themes.Default/App_Start/UnityConfig.cs
+++ b/Atomia.Store.Themes.Default/App_Start/UnityConfig.cs
@@ -177,13 +177,9 @@ namespace Atomia.Store.Themes.Default
             container.RegisterType<OrderDataHandler, Atomia.Store.PublicOrderHandlers.CartItemHandlers.DefaultHandler>("Default");
             container.RegisterType<OrderDataHandler, Atomia.Store.PublicOrderHandlers.CartItemHandlers.SetupFeesHandler>("SetupFees");
             container.RegisterType<OrderDataHandler, Atomia.Store.PublicOrderHandlers.CartItemHandlers.RemovePostOrderHandler>("RemovePostOrder");
+            container.RegisterType<OrderDataHandler, PublicOrderHandlers.PackageGroupIdHandler>("PackageGroupId");
 
             container.RegisterType<IOrderPlacementService, Atomia.Store.PublicBillingApi.Adapters.OrderPlacementService>();
-
-            if (IsMultipackageEnabled())
-            {
-                container.RegisterType<OrderDataHandler, PublicOrderHandlers.PackageGroupIdHandler>("PackageGroupId");
-            }
 
             var orderDataHandlerParams = GetOrderDataHandlerParams();
 
@@ -241,13 +237,9 @@ namespace Atomia.Store.Themes.Default
                 // This is a good position for handlers that add extra items depending on other items in cart, e.g. like HST-APPY in old order page.
 
                 // RemovePostOrder should be placed last to make sure any added postal fees are removed, since they will be added by Atomia Billing.
-                new ResolvedParameter<OrderDataHandler>("RemovePostOrder")
+                new ResolvedParameter<OrderDataHandler>("RemovePostOrder"),
+                new ResolvedParameter<OrderDataHandler>("PackageGroupId")
             };
-
-            if (IsMultipackageEnabled())
-            {
-                orderDataHandlerParams.Add(new ResolvedParameter<OrderDataHandler>("PackageGroupId"));
-            }
 
             return new ResolvedArrayParameter<OrderDataHandler>(orderDataHandlerParams.ToArray());
         }
@@ -284,20 +276,6 @@ namespace Atomia.Store.Themes.Default
             var orderDataHandlerParams = GetOrderDataHandlerParams();
             container.RegisterType<OrderCreator, CombinedOrderCreator>(
                     new InjectionConstructor(orderDataHandlerParams, new ResolvedParameter<PublicBillingApiProxy>(), new ResolvedParameter<IAuditLogger>()));
-        }
-
-        /// <summary>
-        /// Checks if the multipackage is enabled in the configuration.
-        /// </summary>
-        /// <returns></returns>
-        private static bool IsMultipackageEnabled()
-        {
-            var multipackageAppSetting = ConfigurationManager.AppSettings["MultipackageEnabled"];
-            var multipackageValue = false;
-
-            bool.TryParse(multipackageAppSetting, out multipackageValue);
-
-            return multipackageValue;
         }
     }
 }


### PR DESCRIPTION
Added package group id order handler in case when the multipackage is
enabled. The purpose of this handler is to add a PackageGroupId
(GUID) to the order custom attributes dictionary.

Partially resolves PROD-2066.

ChangeLog:
* [NEW] - Added package group id handler.